### PR TITLE
Fix list keys

### DIFF
--- a/app/(tabs)/group/index.tsx
+++ b/app/(tabs)/group/index.tsx
@@ -241,7 +241,7 @@ export default function Group() {
             Group Goals
           </Text>
           {groupGoals.map((goal) => (
-            <CollapsibleContainer>
+            <CollapsibleContainer key={goal.goalId}>
               <View>
                 <View style={styles.row}>
                   <View style={styles.box}>
@@ -294,6 +294,7 @@ export default function Group() {
               <View style={[styles.row, { gap: 10, flexWrap: "wrap" }]}>
                 {Object.entries(goal.progress).map(([userId, progress]) => (
                   <NameProgress
+                    key={userId}
                     name={group.users[userId]}
                     progress={progress}
                     target={goal.target}
@@ -307,7 +308,7 @@ export default function Group() {
         <View style={globalStyles.section}>
           <Text style={globalStyles.sectionHeader}>Members</Text>
           {Object.entries(group.users).map(([userId, name]) => (
-            <View key={name}>
+            <View key={userId}>
               <CollapsibleContainer>
                 <View style={styles.row}>
                   <View style={styles.row}>
@@ -337,9 +338,9 @@ export default function Group() {
                   </View>
                 </View>
                 <View>
-                  {userGoals.get(userId)?.map((activity, index) => (
+                  {userGoals.get(userId)?.map((activity) => (
                     <ProgressBarTextIcon
-                      key={index}
+                      key={activity.goalId}
                       progress={activity.progress[userId]}
                       target={activity.target}
                       unit={metricMetadata[activity.metric].unit}

--- a/app/(tabs)/group/settings.tsx
+++ b/app/(tabs)/group/settings.tsx
@@ -426,7 +426,7 @@ export default function GroupSettings() {
         <Collapsible title="Members" style={{ marginTop: 6 }}>
           {members.map((member, index) => (
             <SettingsMember
-              key={index}
+              key={member[0]}
               user={{ userId: member[0], name: member[1] }}
               onRemove={() => promptRemoveMember(index)}
             />
@@ -472,7 +472,7 @@ export default function GroupSettings() {
           {groupGoals.map((goal, index) => (
             <SettingsGoal
               unit={""}
-              key={index}
+              key={goal.goalId}
               {...goal}
               onRemove={() => promptRemoveGoal(index)}
             />
@@ -493,7 +493,7 @@ export default function GroupSettings() {
 
         <Collapsible title="Individual Goals">
           {members.map(([memberId, memberName], memberIndex) => (
-            <CollapsibleContainer key={memberIndex}>
+            <CollapsibleContainer key={memberId}>
               <View
                 style={[
                   styles.row,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -126,6 +126,7 @@ export default function Main() {
         <Collapsible title="Goals" style={{ marginTop: 6 }}>
           {goals.map((goal) => (
             <GoalContainer
+              key={goal.goalId}
               activity={goal.activity}
               metric={goal.metric}
               progress={goal.progress.amount}
@@ -146,9 +147,9 @@ export default function Main() {
             />
           </TouchableOpacity>
         </View>
-        {groups.map((group, index) => (
+        {groups.map((group) => (
           <TouchableOpacity
-            key={index}
+            key={group.groupId}
             onPress={() =>
               router.push({
                 pathname: "/group",

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -70,7 +70,7 @@ export default function Profile() {
         </Text>
         {invites.map((invite, index) => (
           <Invite
-            key={index}
+            key={invite.inviteId}
             {...invite}
             handleInvite={(answer: InviteAnswer) => {
               inviteAnswer(answer, index);


### PR DESCRIPTION
For performance reasons, elements in a list must always be uniquely identified with a `key` value. The element's index in the list is NOT a unique identifier.